### PR TITLE
Change chapter number and name of raw chapter

### DIFF
--- a/shindex2.json
+++ b/shindex2.json
@@ -885,8 +885,8 @@
       },
       "last_updated": "1623865832"
     },
-    "104": {
-      "title": "The Name of a Certain Girl",
+    "104.001": {
+      "title": "(Raw) The Name of a Certain Girl",
       "volume": "9",
       "groups": {
         "Palmtop Scans": "/proxy/api/imgur/chapter/Gd6FD1s/"


### PR DESCRIPTION
Please indicate in the chapter name which chapters are raws. This will help people who follow the Cubari link know when the translated version of the chapter has been posted. Additionally, please use a different chapter number for raws to ensure that people using Tachiyomi to follow the Cubari link are notified when the translated version is posted. (If a Tachiyomi user had previously marked the raw chapter as "read", when the translated chapter is posted with the same chapter number it may still show up as "read", and thus the user will not know that a new translated chapter was posted because there is no "unread" icon.)

This pull request is obviously only a suggestion, if you prefer to use a different chapter number other than ".001" or prefer to put the "(Raw)" at the end of the title or whatever, feel free to reject or edit this pull request.